### PR TITLE
Add _verbose_message for debugging.

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -114,11 +114,9 @@ _verbose_message(const char *message, const char *args)
         // confirm the prefix of message matches any keyword
         bool startswith_keywords = false;
 
-        if (strlen(message) >= 1 && strncmp(message, "#", 1) == 0) {
-            startswith_keywords = true;
-        }
-
-        if (strlen(message) >= 7 && strncmp(message, "import ", 7) == 0) {
+        if (strlen(message) >= 1 && (
+            strncmp(message, "#", 1) == 0 || strncmp(message, "import ", 7) == 0
+        )) {
             startswith_keywords = true;
         }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -114,11 +114,11 @@ _verbose_message(const char *message, const char *args)
         // confirm the prefix of message matches any keyword
         bool startswith_keywords = false;
 
-        if (strlen(message) >= 1 && (strncmp(message, "#", 1) == 0)) {
+        if (strlen(message) >= 1 && strncmp(message, "#", 1) == 0) {
             startswith_keywords = true;
         }
 
-        if (strlen(message) >= 7 && strncmp(message, "import ", 7) == 0)) {
+        if (strlen(message) >= 7 && strncmp(message, "import ", 7) == 0) {
             startswith_keywords = true;
         }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -112,17 +112,11 @@ _verbose_message(const char *message, const char *args)
 
     if (verbose) {
         // confirm the prefix of message matches any keyword
-        bool startswith_keywords = false;
-
         if (strlen(message) >= 1 && (
             strncmp(message, "#", 1) == 0 || strncmp(message, "import ", 7) == 0
         )) {
-            startswith_keywords = true;
-        }
-
-        if (startswith_keywords) {
             // match keyword, just print it
-            fprintf (stderr, message, args);
+            fprintf(stderr, message, args);
         }
         else {
             // rebuild output message
@@ -130,7 +124,7 @@ _verbose_message(const char *message, const char *args)
             char *new_message = malloc(strlen(new_prefix) + strlen(message) + 1); // allocate memory
             strcpy(new_message, new_prefix);
             strcat(new_message, message);
-            fprintf (stderr, new_message, args);
+            fprintf(stderr, new_message, args);
 
             free(new_message); // free the memory
             new_message = NULL;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->

# Summary
Port `_verbose_message` from `Lib/importlib/_bootstrap.py` to `Python/import.c`. Also, use them to replace the original logging code of deferred imports.

# Test Plan
I will use seven different ways to test my implementation. Tests 1 to 4 will test executing Python with different flags. Besides, Tests 5 and 6 will validate Python by setting the different environment variables. For Test 7, we need to modify some code in `import.c` to confirm the logging still works correctly when the message does not start with keywords (`#` and `import `). That is also the reason why I do not use unit tests to wrap them.

**Note**: The only way to enable Lazy Imports in the omg branch is using `-L`, so we will not include Lazy Imports' environment variable testing in our test.

## 1. Without any flag

- Run `./python.exe `
- Try to `import math `

It should show nothing in the logging when importing math.
```
$ ./python.exe
>>> import math
```

**Expected Result:**

![image](https://user-images.githubusercontent.com/18440101/173124703-dfc2b9ed-b4e5-44be-975c-27efc98aea12.png)


## 2. With the verbose flag

- Run `./python.exe -v `
- Try to ` import math `

There will be a lot of messages when starting Python, but it should not show any logging related to Lazy Imports (at the begging/when importing math).
```
$ ./python.exe -v
>>> import math
```

**Expected Result:**

![image](https://user-images.githubusercontent.com/18440101/173124971-f487b3fa-7b83-4391-bdd6-af0cd0b41050.png)

## 3. With the Lazy Imports flag

- Run `./python.exe -L `
- Try to ` import math `

It will not show any logging when importing math.

```
$ ./python.exe -L
>>> import math
```

**Expected Result:**

![image](https://user-images.githubusercontent.com/18440101/173125025-d8f4282f-967e-477a-861d-f3ba5f4fbbe1.png)


## 4. With flags of verbose and Lazy Imports

- Run `./python.exe -L -v `
- Try to ` import math `

There will be a lot of Lazy Imports loggings when starting Python. Moreover, it will show the log `# lazy import 'math'` when importing math.
```
$ ./python.exe -L -v
>>> import math
```

**Expected Result:**

![image](https://user-images.githubusercontent.com/18440101/173125103-54205e0c-5fb4-4802-b498-31814ddf0733.png)


## 5. Set verbose environment variable only

- Open a new terminal (default setting of environment variables)
- Set verbose mode `export PYTHONVERBOSE=1`
- Run `./python.exe `
- Try to ` import math `

It will have the same situation as **Test 2**. That is, it will have a lot of logs but without Lazy Imports logs. To be more specific, `# lazy import 'math'` will **not** show when importing math.

```
$ export PYTHONVERBOSE=1
$ ./python.exe
>>> import math
```

**Expected Result:**

![image](https://user-images.githubusercontent.com/18440101/173125177-c833d71d-5ffc-4836-86af-6d61ab4a38ff.png)

## 6. Set verbose environment variable and use Lazy Imports flag

- Open a new terminal (default setting of environment variables)
- Set verbose mode `export PYTHONVERBOSE=1`
- Run ./python.exe -v 
- Try to ` import math `

It will have the same situation as **Test 4**. `# lazy import 'math'` will show when importing math.

```
$ export PYTHONVERBOSE=1
$ ./python.exe -v
>>> import math
```

**Expected Result:**

![image](https://user-images.githubusercontent.com/18440101/173125259-d9d2dbdf-66fd-47fa-a042-fce189c87ee2.png)

## 7. Test the logging which does not start with the keywords
Based on the logic of `Lib/importlib/_bootstrap.py`, we need to add the prefix `# ` if the logging message does not start with the keywords which are `#` and `import `. To test this behavior, I add another message without keywords prefix in `PyImport_ImportName`. Then, I check if the output logging is added the prefix `# `.

#### STEPS:
1. Add this logging to PyImport_ImportName in `import.c`
```
_verbose_message("Hey '%s'\n", PyUnicode_AsUTF8(name));
```
![image](https://user-images.githubusercontent.com/18440101/173126176-dc1295eb-d7da-4d59-9f88-3e172262665a.png)

2. Build it. Run `make -j` in your terminal.
3. Test the behavior by using the same way as **Test 4**. 
```
$ ./python.exe -L -v
>>> import math
```

**Expected Result:** 

![image](https://user-images.githubusercontent.com/18440101/173126188-da41e465-1d4d-4284-a745-d44847b59838.png)
We did not include the prefix "# " in our original logging message. However, `_verbose_message` will help to add it when the logging is printed. 😉
